### PR TITLE
Avoid creating temporary matrices

### DIFF
--- a/pyprocessmacro/models.py
+++ b/pyprocessmacro/models.py
@@ -892,11 +892,11 @@ class OLSOutcomeModel(BaseOutcomeModel):
             vcv = np.true_divide(1, n_obs - n_vars) * dot(resid.T, resid) * inv_xx
         elif errortype == 'HC0':
             sq_resid = (resid ** 2).squeeze()
-            vcv = dot(dot(dot(dot(inv_xx, x.T), np.diag(sq_resid)), x), inv_xx)
+            vcv = dot(dot(dot(inv_xx, x.T) * sq_resid, x), inv_xx)
         elif errortype == 'HC1':
             sq_resid = (resid ** 2).squeeze()
             vcv = np.true_divide(n_obs, n_obs - n_vars - 1) * \
-                  dot(dot(dot(dot(inv_xx, x.T), np.diag(sq_resid)), x), inv_xx)
+                  dot(dot(dot(inv_xx, x.T) * sq_resid, x), inv_xx)
         elif errortype == 'HC2':
             sq_resid = (resid ** 2).squeeze()
             H = (x.dot(inv_xx) * x).sum(axis=-1)

--- a/pyprocessmacro/models.py
+++ b/pyprocessmacro/models.py
@@ -899,8 +899,8 @@ class OLSOutcomeModel(BaseOutcomeModel):
                   dot(dot(dot(dot(inv_xx, x.T), np.diag(sq_resid)), x), inv_xx)
         elif errortype == 'HC2':
             sq_resid = (resid ** 2).squeeze()
-            H = np.diagonal(dot(dot(x, inv_xx), x.T))
-            vcv = dot(dot(dot(dot(inv_xx, x.T), np.diag(sq_resid / (1 - H))), x), inv_xx)
+            H = (x.dot(inv_xx) * x).sum(axis=-1)
+            vcv = dot(dot(dot(inv_xx, x.T) * (sq_resid / (1 - H)), x), inv_xx)
         elif errortype == 'HC3':
             sq_resid = (resid ** 2).squeeze()
             H = (x.dot(inv_xx) * x).sum(axis=-1)

--- a/pyprocessmacro/models.py
+++ b/pyprocessmacro/models.py
@@ -903,8 +903,8 @@ class OLSOutcomeModel(BaseOutcomeModel):
             vcv = dot(dot(dot(dot(inv_xx, x.T), np.diag(sq_resid / (1 - H))), x), inv_xx)
         elif errortype == 'HC3':
             sq_resid = (resid ** 2).squeeze()
-            H = np.diagonal(dot(dot(x, inv_xx), x.T))
-            vcv = dot(dot(dot(dot(inv_xx, x.T), np.diag(sq_resid / ((1 - H) ** 2))), x), inv_xx)
+            H = (x.dot(inv_xx) * x).sum(axis=-1)
+            vcv = dot(dot(dot(inv_xx, x.T) * (sq_resid / ((1 - H) ** 2)), x), inv_xx)
         else:
             raise ValueError("The covariance type {} is not supported. Please specify 'standard', 'HC0'"
                              "'HC1', 'HC2', or 'HC3".format(errortype))


### PR DESCRIPTION
Hi,

The previous code was giving me the memory error when the size of the x was large (like 100,000). I re-wrote the calculations of `H` and `vcv` using element-wise multiplications whenever possible so they avoid creating large temporary matrices. 

I verified that it yielded the correct results with my data and uses much less memory. 
